### PR TITLE
Fix drag suppression logic for contact modal clicks

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,6 +33,8 @@ let trackPointerId = null;
 let trackPointerStartX = 0;
 let trackPointerScrollStart = 0;
 let trackWasDragged = false;
+let trackPointerCaptured = false;
+const TRACK_DRAG_THRESHOLD = 12;
 
 const defaultContacts = [
   {
@@ -392,34 +394,50 @@ track?.addEventListener("pointerdown", (event) => {
   trackPointerId = event.pointerId;
   trackPointerStartX = event.clientX;
   trackPointerScrollStart = track.scrollLeft;
-  track.setPointerCapture?.(trackPointerId);
-  track.classList.add("dragging");
+  trackPointerCaptured = false;
+  track.classList.remove("dragging");
 });
 
 track?.addEventListener("pointermove", (event) => {
   if (!isTrackPointerDown || !track) return;
   const deltaX = event.clientX - trackPointerStartX;
-  if (Math.abs(deltaX) > 3) {
-    trackWasDragged = true;
+  if (Math.abs(deltaX) < TRACK_DRAG_THRESHOLD) {
+    return;
   }
+  if (!trackPointerCaptured && trackPointerId !== null) {
+    try {
+      track.setPointerCapture?.(trackPointerId);
+      trackPointerCaptured = true;
+    } catch (error) {
+      trackPointerCaptured = false;
+    }
+  }
+  track.classList.add("dragging");
+  trackWasDragged = true;
   track.scrollLeft = trackPointerScrollStart - deltaX;
 });
 
 const releaseTrackPointer = () => {
   if (!isTrackPointerDown || !track) return;
+  const didDrag = trackWasDragged;
   isTrackPointerDown = false;
-  if (trackPointerId !== null) {
+  if (trackPointerCaptured && trackPointerId !== null) {
     try {
       track.releasePointerCapture?.(trackPointerId);
     } catch (error) {
       // ignore
     }
-    trackPointerId = null;
   }
+  trackPointerId = null;
+  trackPointerCaptured = false;
   track.classList.remove("dragging");
-  setTimeout(() => {
+  if (didDrag) {
+    requestAnimationFrame(() => {
+      trackWasDragged = false;
+    });
+  } else {
     trackWasDragged = false;
-  }, 0);
+  }
 };
 
 track?.addEventListener("pointerup", releaseTrackPointer);


### PR DESCRIPTION
## Summary
- rely on pointer move detection instead of scroll delta when deciding whether a drag occurred
- reset the drag flag on the next animation frame so genuine clicks can open contact cards again

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e552dc82d883239d54998eef6c8d91